### PR TITLE
Hotfix: Fix CI test failures from ~maybe construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Kinda introduces **uncertainty as a first-class concept** with the `~` (tilde) p
     ~sorta print("Probably big!")
     x ~= x + 1           # Fuzzy reassignment
 }
+~maybe (x > 39) {        # More likely conditional (60% chance)
+    ~sorta print("Quite likely big!")
+}
 ```
 
 **Every time you run this, it behaves differently.** That's the point.
@@ -69,6 +72,7 @@ kinda examples  # Try some examples
 | `~kinda int x ~= 42` | Fuzzy integer (±1 noise) | `x` might be 41, 42, or 43 |
 | `~sorta print(msg)` | Maybe prints (80% chance) | Sometimes prints, sometimes `[shrug]` |
 | `~sometimes (cond) {}` | Random conditional (50%) | Block runs if both random AND condition |
+| `~maybe (cond) {}` | Less random conditional (60%) | More likely than ~sometimes but still fuzzy |
 | `x ~= x + 1` | Fuzzy assignment | Adds 1 ± random noise |
 
 ## 🎯 Why Use Kinda?

--- a/kinda/cli.py
+++ b/kinda/cli.py
@@ -41,7 +41,7 @@ def show_examples():
     examples = [
         ("Hello World", "examples/hello.py.knda", "The classic, but fuzzy"),
         ("Chaos Greeter", "examples/unified_syntax.py.knda", "Variables that kinda work"),
-        ("Maybe Math", None, "~kinda int x = 5\n~kinda int y ~= 10\n~sometimes (x < y) {\n    ~sorta print(\"Math happened!\")\n}"),
+        ("Maybe Math", "examples/python/maybe_example.py.knda", "Fuzzy conditionals with ~sometimes and ~maybe"),
     ]
     
     for title, filename, description in examples:
@@ -69,6 +69,7 @@ def show_syntax_reference():
         ("~kinda int y ~= 10", "Extra fuzzy assignment"),
         ("~sorta print(x)", "Maybe prints (80% chance)"),
         ("~sometimes (x > 0) { }", "Random conditional (50% chance)"),
+        ("~maybe (x > 0) { }", "Less random conditional (60% chance)"),
         ("x ~= x + 1", "Fuzzy reassignment"),
     ]
     

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,9 +50,9 @@ class TestCLICommands:
         expected = normalize_emoji_output("🎲 Here are some kinda programs to get you started:")
         assert expected in normalize_emoji_output(output)
         assert "Hello World" in output
-        assert "~kinda int" in output
-        assert "~sorta print" in output
+        assert "Fuzzy conditionals" in output
         assert "~sometimes" in output
+        assert "~maybe" in output
         assert "Pro tip:" in output
 
     def test_syntax_command(self, capsys):
@@ -114,7 +114,7 @@ class TestCLIIntegration:
         assert result.returncode == 0
         expected = normalize_emoji_output("🎲 Here are some kinda programs")
         assert expected in normalize_emoji_output(result.stdout)
-        assert "~kinda int" in result.stdout
+        assert "Fuzzy conditionals" in result.stdout
 
     def test_syntax_command_integration(self):
         """Test syntax command via subprocess"""  


### PR DESCRIPTION
## Summary
This PR fixes CI test failures that occurred after merging the ~maybe construct implementation.

## Problem
The ~maybe construct documentation changes were committed directly to main instead of being included in the original PR #43. This caused CI tests to fail because:
- CLI examples were updated to show maybe_example.py.knda
- Tests still expected to see ~kinda int in the output

## Solution
- Updated test assertions to match the new examples output
- All documentation and test changes are now properly included

## Testing
- All 163 tests now pass locally
- CI should pass after this fix

## Lessons Learned
This highlights the importance of:
1. **ALWAYS checking git status** before creating PRs
2. **NEVER committing directly to main**
3. **Running full test suite** before pushing

The coder agent profile has been updated with stronger requirements to prevent this in the future.